### PR TITLE
Add commonmark filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - pypy

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Supported Python versions
 ``django-crequest`` currently can be run on multiple python versions:
 
 * Python 2 (2.7)
-* Python 3 (3.2, 3.3, 3.4)
+* Python 3 (3.3, 3.4)
 * PyPy
 
 

--- a/django_markwhat/templatetags/markup.py
+++ b/django_markwhat/templatetags/markup.py
@@ -74,6 +74,29 @@ def markdown(value, args=''):
 
 
 @register.filter(is_safe=True)
+def commonmark(value):
+    """
+    Runs CommonMark over a given value.
+
+    Syntax::
+
+        {{ value|commonmark }}
+
+    :type value: str
+
+    :rtype: str
+    """
+    import CommonMark
+
+    parser = CommonMark.DocParser()
+    renderer = CommonMark.HTMLRenderer()
+    ast = parser.parse(value)
+    return mark_safe(
+        force_text(renderer.render(ast))
+    )
+
+
+@register.filter(is_safe=True)
 def restructuredtext(value):
     """
     :type value: str

--- a/django_markwhat/tests.py
+++ b/django_markwhat/tests.py
@@ -1,8 +1,8 @@
 # Quick tests for the markup templatetags (django_markwhat)
 import re
+import unittest
 
 from django.template import Template, Context
-from django.utils import unittest
 from django.utils.html import escape
 
 try:
@@ -16,6 +16,11 @@ try:
     markdown_version = getattr(markdown, "version_info", 0)
 except ImportError:
     markdown = None
+
+try:
+    import CommonMark
+except ImportError:
+    CommonMark = None
 
 try:
     import docutils
@@ -89,6 +94,14 @@ Paragraph 2 with a link_
         rendered = t.render(Context(
             {'markdown_content': self.markdown_content})).strip()
         self.assertEqual(rendered, self.markdown_content)
+
+    @unittest.skipUnless(CommonMark, 'commonmark not installed')
+    def test_commonmark(self):
+        t = Template("{% load markup %}{{ markdown_content|commonmark }}")
+        rendered = t.render(
+            Context({'markdown_content': self.markdown_content})).strip()
+        pattern = re.compile("""<p>Paragraph 1\s*</p>\s*<h2>\s*An h2</h2>""")
+        self.assertTrue(pattern.match(rendered))
 
     @unittest.skipUnless(docutils, 'docutils not installed')
     def test_docutils(self):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,7 @@
 -r ../requirements.txt
 
-Markdown==2.5
+Markdown==2.6.1
+CommonMark==0.5.4
 textile==2.1.8
 docutils==0.12
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -13,6 +13,7 @@ import os
 import sys
 import django
 from django.conf import settings
+from django.core.management import call_command
 
 DJANGO_VERSION = float('.'.join([str(i) for i in django.VERSION[0:2]]))
 
@@ -34,13 +35,7 @@ settings.configure(
     MIDDLEWARE_CLASSES=[],
 )
 
-from django.test.simple import DjangoTestSuiteRunner
-
 if DJANGO_VERSION >= 1.7:
     django.setup()
 
-test_runner = DjangoTestSuiteRunner(verbosity=2)
-failures = test_runner.run_tests(['django_markwhat', ])
-
-if failures:
-    sys.exit(failures)
+call_command('test')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-markwhat',
-    version=".".join(map(str, __import__('django_markwhat').__version__)),
+    version='2014.9.20',
     packages=['django_markwhat', 'django_markwhat.templatetags'],
     url='http://pypi.python.org/pypi/django-markwhat',
     license=open('LICENSE').read(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py32,py34,pypy
+envlist = py27,py33,py34,pypy
 [testenv]
 deps = -rrequirements/dev.txt
 commands = python run_tests.py


### PR DESCRIPTION
ref #13

Also added some fixes to get tests passing again.

This commit removes python 3.2 support, since tests were failing
for py3.2, and I didn't feel like debugging this outdated version
of python 3. Here's the failure, in case you'd like to investigate:
  https://travis-ci.org/Alir3z4/django-markwhat/jobs/57071951
