### PR TITLE
Force commonmark input to a string to prevent exception

### DIFF
--- a/django_markwhat/templatetags/markup.py
+++ b/django_markwhat/templatetags/markup.py
@@ -90,7 +90,7 @@ def commonmark(value):
 
     parser = CommonMark.DocParser()
     renderer = CommonMark.HTMLRenderer()
-    ast = parser.parse(value)
+    ast = parser.parse(force_text(value))
     return mark_safe(
         force_text(renderer.render(ast))
     )

--- a/django_markwhat/tests.py
+++ b/django_markwhat/tests.py
@@ -103,6 +103,18 @@ Paragraph 2 with a link_
         pattern = re.compile("""<p>Paragraph 1\s*</p>\s*<h2>\s*An h2</h2>""")
         self.assertTrue(pattern.match(rendered))
 
+    @unittest.skipUnless(CommonMark, 'commonmark not installed')
+    def test_commonmark_empty_str(self):
+        t = Template("{% load markup %}{{ markdown_content|commonmark }}")
+        rendered = t.render(Context({'markdown_content': ''})).strip()
+        self.assertEqual(rendered, '')
+
+    @unittest.skipUnless(CommonMark, 'commonmark not installed')
+    def test_commonmark_none(self):
+        t = Template("{% load markup %}{{ markdown_content|commonmark }}")
+        rendered = t.render(Context({'markdown_content': None})).strip()
+        self.assertEqual(rendered, '<p>None</p>')
+
     @unittest.skipUnless(docutils, 'docutils not installed')
     def test_docutils(self):
         t = Template("{% load markup %}{{ rest_content|restructuredtext }}")


### PR DESCRIPTION
I ran into a bug with my commonmark renderer - if the input
is None it throws an exception. This change should fix that.