### PR TITLE
Add compatibility with commonmark-0.6.0

### DIFF
--- a/django_markwhat/templatetags/markup.py
+++ b/django_markwhat/templatetags/markup.py
@@ -90,8 +90,8 @@ def commonmark(value):
     """
     import CommonMark
 
-    parser = CommonMark.DocParser()
-    renderer = CommonMark.HTMLRenderer()
+    parser = CommonMark.Parser()
+    renderer = CommonMark.HtmlRenderer()
     ast = parser.parse(force_text(value))
     return mark_safe(
         force_text(renderer.render(ast))

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r ../requirements.txt
 
 Markdown==2.6.2
-CommonMark==0.5.4
+CommonMark==0.6.1
 textile==2.2.2
 docutils==0.12
 flake8==2.4.1


### PR DESCRIPTION
CommonMark-py 0.6.0 has a new API.