### PR TITLE
import setup from setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='django-markwhat',


### PR DESCRIPTION
To allow for wheel creation with bdist_wheel.

See: http://stackoverflow.com/a/27868004/173630