### PR TITLE
Don't call force_text on commonmark output

### DIFF
--- a/django_markwhat/templatetags/markup.py
+++ b/django_markwhat/templatetags/markup.py
@@ -93,9 +93,7 @@ def commonmark(value):
     parser = CommonMark.Parser()
     renderer = CommonMark.HtmlRenderer()
     ast = parser.parse(force_text(value))
-    return mark_safe(
-        force_text(renderer.render(ast))
-    )
+    return mark_safe(renderer.render(ast))
 
 
 @register.filter(is_safe=True)


### PR DESCRIPTION
To fix the error:
> 'ascii' codec can't encode character u'\u2022' in position 47: ordinal
not in range(128)

I will come up with a test for this as well.