### PR TITLE
remove arguments in call to textile.textile()

### DIFF
--- a/django_markwhat/templatetags/markup.py
+++ b/django_markwhat/templatetags/markup.py
@@ -32,7 +32,7 @@ def textile(value):
     import textile
 
     return mark_safe(force_text(
-        textile.textile(smart_str(value), encoding='utf-8', output='utf-8'))
+        textile.textile(smart_str(value)))
     )
 
 


### PR DESCRIPTION
`textile` removed the `encoding` and `output` arguments in this commit:

https://github.com/textile/python-textile/commit/788895c6e273789559c25f1d73bb6d33a6800dcc

Which was released in 2.3.13, causing markwhat's tests to fail.

It appears that they have been ignored for some time now anyway.