### PR TITLE
use keyword arguments for Markdown

### DIFF
--- a/django_markwhat/templatetags/markup.py
+++ b/django_markwhat/templatetags/markup.py
@@ -69,7 +69,7 @@ def markdown(value, args=''):
 
     return mark_safe(markdown.markdown(
         force_text(value),
-        extensions,
+        extensions=extensions,
         safe_mode=safe_mode,
         enable_attributes=(not safe_mode)
     ))


### PR DESCRIPTION
As mentioned in the Markdown 3.0 release notes, positional arguments are no longer supported:

https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.0.md#positional-arguments-deprecated

This causes an exception like:

```
======================================================================
ERROR: test_markdown_html_iframe_code (django_markwhat.tests.Templates)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/django-markwhat/django_markwhat/tests.py", line 108, in test_markdown_html_iframe_code
    'markdown_content': self.markdown_content_with_iframe_code
  File "/tmp/ve/local/lib/python2.7/site-packages/django/template/base.py", line 207, in render
    return self._render(context)
  File "/tmp/ve/local/lib/python2.7/site-packages/django/test/utils.py", line 107, in instrumented_test_render
    return self.nodelist.render(context)
  File "/tmp/ve/local/lib/python2.7/site-packages/django/template/base.py", line 990, in render
    bit = node.render_annotated(context)
  File "/tmp/ve/local/lib/python2.7/site-packages/django/template/base.py", line 957, in render_annotated
    return self.render(context)
  File "/tmp/ve/local/lib/python2.7/site-packages/django/template/base.py", line 1040, in render
    output = self.filter_expression.resolve(context)
  File "/tmp/ve/local/lib/python2.7/site-packages/django/template/base.py", line 736, in resolve
    new_obj = func(obj, *arg_vals)
  File "/django-markwhat/django_markwhat/templatetags/markup.py", line 74, in markdown
    enable_attributes=(not safe_mode)
TypeError: markdown() takes exactly 1 argument (4 given)
```

This PR changes the call to pass `extensions` as a keyword argument.